### PR TITLE
DDF-2229 upgrade ogc-filter-v_1_1_0 schema to include fuzzy search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 *.metadata
 *.iml
 *.idea
+.DS_Store
 target/
 bin/

--- a/ogc-filter-v_1_1_0-schema/pom.xml
+++ b/ogc-filter-v_1_1_0-schema/pom.xml
@@ -18,7 +18,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.codice.thirdparty</groupId>
   <artifactId>ogc-filter-v_1_1_0-schema</artifactId>
-  <version>1.1.0_2</version>
+  <version>1.1.0_3</version>
   <name>DDF :: Thirdparty :: OGC Filter Schema 1.1.0 Bindings</name>
   <description>Provides JAXB 2.x bindings for OGC Filter Schema (Version 1.1.0).</description>
 

--- a/ogc-filter-v_1_1_0-schema/src/main/resources/filter/1.1.0/filter.xsd
+++ b/ogc-filter-v_1_1_0-schema/src/main/resources/filter/1.1.0/filter.xsd
@@ -76,6 +76,9 @@ Copyright © 1994-2012 Open Geospatial Consortium, Inc.
    <xsd:element name="PropertyIsLike"
                 type="ogc:PropertyIsLikeType"
                 substitutionGroup="ogc:comparisonOps"/>
+   <xsd:element name="PropertyIsFuzzy"
+                type="ogc:PropertyIsFuzzyType"
+                substitutionGroup="ogc:comparisonOps"/>
    <xsd:element name="PropertyIsNull"
                 type="ogc:PropertyIsNullType"
                 substitutionGroup="ogc:comparisonOps"/>
@@ -166,6 +169,16 @@ Copyright © 1994-2012 Open Geospatial Consortium, Inc.
             <xsd:attribute name="singleChar" type="xsd:string" use="required"/>
             <xsd:attribute name="escapeChar" type="xsd:string" use="required"/>
             <xsd:attribute name="matchCase" type="xsd:boolean" use="optional" default="true"/>
+         </xsd:extension>
+      </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="PropertyIsFuzzyType">
+      <xsd:complexContent>
+         <xsd:extension base="ogc:ComparisonOpsType">
+            <xsd:sequence>
+               <xsd:element ref="ogc:PropertyName"/>
+               <xsd:element ref="ogc:Literal"/>
+            </xsd:sequence>
          </xsd:extension>
       </xsd:complexContent>
    </xsd:complexType>

--- a/ogc-filter-v_1_1_0-schema/src/main/resources/filter/1.1.0/filterCapabilities.xsd
+++ b/ogc-filter-v_1_1_0-schema/src/main/resources/filter/1.1.0/filterCapabilities.xsd
@@ -123,6 +123,7 @@
          <xsd:enumeration value="Like"/>
          <xsd:enumeration value="Between"/>
          <xsd:enumeration value="NullCheck"/>
+         <xsd:enumeration value="Fuzzy"/>
       </xsd:restriction>
    </xsd:simpleType>
    <xsd:complexType name="ArithmeticOperatorsType">

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
 		<module>lucene-core-3.0.2</module>
 		<module>cas-client-core-3.1.10</module>
 		<module>vecmath-1.3.2</module>
+		<module>ogc-filter-v_1_1_0-schema</module>
 		<module>ffmpeg</module>
 	</modules>
 


### PR DESCRIPTION
Adds an element for fuzzy searches in the ogc-filter-v_1_1_0 schema