### PR TITLE
DDF-3071 upgrade filter schema to 1.1.3

### DIFF
--- a/ogc-filter-v_1_1_0-schema/pom.xml
+++ b/ogc-filter-v_1_1_0-schema/pom.xml
@@ -12,12 +12,13 @@
  *
  **/
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.codice.thirdparty</groupId>
   <artifactId>ogc-filter-v_1_1_0-schema</artifactId>
-  <version>1.1.0_3</version>
+    <version>1.1.0_4</version>
   <name>Codice :: Thirdparty :: OGC Filter Schema 1.1.0 Bindings</name>
   <description>Provides JAXB 2.x bindings for OGC Filter Schema (Version 1.1.0).</description>
 

--- a/ogc-filter-v_1_1_0-schema/pom.xml
+++ b/ogc-filter-v_1_1_0-schema/pom.xml
@@ -74,7 +74,7 @@
             </goals>
             <configuration>
               <schemaIncludes>
-                <value>filter/*/filter.xsd</value>
+                  <value>filter/*/filterAll.xsd</value>
                 <value>gml/*/base/gml.xsd</value>
               </schemaIncludes>
               <episodes>

--- a/ogc-filter-v_1_1_0-schema/src/main/resources/binding.xjb
+++ b/ogc-filter-v_1_1_0-schema/src/main/resources/binding.xjb
@@ -4,7 +4,7 @@
 	jaxb:extensionBindingPrefixes="xjc">
 
 	<jaxb:bindings 
-		schemaLocation="filter/1.1.0/filter.xsd" 
+		schemaLocation="filter/1.1.0/filterAll.xsd"
 		node="/xs:schema">
 		<jaxb:globalBindings
 			fixedAttributeAsConstantProperty="true"

--- a/ogc-filter-v_1_1_0-schema/src/main/resources/filter/1.1.0/expr.xsd
+++ b/ogc-filter-v_1_1_0-schema/src/main/resources/filter/1.1.0/expr.xsd
@@ -1,70 +1,71 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsd:schema xmlns:ogc="http://www.opengis.net/ogc"
-            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            targetNamespace="http://www.opengis.net/ogc"
-            elementFormDefault="qualified"
-            version="1.1.3">
-    <!--
-       filter is an OGC Standard.
-       Copyright (c) 2002,2003,2004,2010 Open Geospatial Consortium.
-       To obtain additional rights of use, visit http://www.opengeospatial.org/legal/ .
-
-       Updated: 2012-07-21
-    -->
-    <xsd:element name="Add" type="ogc:BinaryOperatorType"
-                 substitutionGroup="ogc:expression"/>
-    <xsd:element name="Sub" type="ogc:BinaryOperatorType"
-                 substitutionGroup="ogc:expression"/>
-    <xsd:element name="Mul" type="ogc:BinaryOperatorType"
-                 substitutionGroup="ogc:expression"/>
-    <xsd:element name="Div" type="ogc:BinaryOperatorType"
-                 substitutionGroup="ogc:expression"/>
-    <xsd:element name="PropertyName" type="ogc:PropertyNameType"
-                 substitutionGroup="ogc:expression"/>
-    <xsd:element name="Function" type="ogc:FunctionType"
-                 substitutionGroup="ogc:expression"/>
-    <xsd:element name="Literal" type="ogc:LiteralType"
-                 substitutionGroup="ogc:expression"/>
-    <xsd:element name="expression" type="ogc:ExpressionType" abstract="true"/>
-    <!-- <xsd:complexType name="ExpressionType" abstract="true" mixed="true"/>
-      -->
-    <xsd:complexType name="ExpressionType" abstract="true"/>
-    <xsd:complexType name="BinaryOperatorType">
-        <xsd:complexContent>
-            <xsd:extension base="ogc:ExpressionType">
-                <xsd:sequence>
-                    <xsd:element ref="ogc:expression" minOccurs="2" maxOccurs="2"/>
-                </xsd:sequence>
-            </xsd:extension>
-        </xsd:complexContent>
-    </xsd:complexType>
-    <xsd:complexType name="FunctionType">
-        <xsd:complexContent>
-            <xsd:extension base="ogc:ExpressionType">
-                <xsd:sequence>
-                    <xsd:element ref="ogc:expression" minOccurs="0"
-                                 maxOccurs="unbounded"/>
-                </xsd:sequence>
-                <xsd:attribute name="name" type="xsd:string" use="required"/>
-            </xsd:extension>
-        </xsd:complexContent>
-    </xsd:complexType>
-    <xsd:complexType name="LiteralType">
-        <xsd:complexContent mixed="true">
-            <xsd:extension base="ogc:ExpressionType">
-                <xsd:sequence>
-                    <xsd:any minOccurs="0"/>
-                </xsd:sequence>
-            </xsd:extension>
-        </xsd:complexContent>
-    </xsd:complexType>
-    <xsd:complexType name="PropertyNameType">
-        <xsd:complexContent mixed="true">
-            <xsd:extension base="ogc:ExpressionType">
-                <xsd:sequence>
-                    <xsd:any minOccurs="0"/>
-                </xsd:sequence>
-            </xsd:extension>
-        </xsd:complexContent>
-    </xsd:complexType>
+<xsd:schema targetNamespace="http://www.opengis.net/ogc"
+   xmlns:ogc="http://www.opengis.net/ogc"
+   xmlns:gml="http://www.opengis.net/gml"
+   xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+   elementFormDefault="qualified"
+   version="1.1.3">
+   <!-- 
+      filter is an OGC Standard.
+      Copyright (c) 2002,2003,2004,2010 Open Geospatial Consortium.
+      To obtain additional rights of use, visit http://www.opengeospatial.org/legal/ .
+      
+      Updated: 2012-07-21
+   -->
+   <xsd:element name="Add" type="ogc:BinaryOperatorType"
+      substitutionGroup="ogc:expression"/>
+   <xsd:element name="Sub" type="ogc:BinaryOperatorType"
+      substitutionGroup="ogc:expression"/>
+   <xsd:element name="Mul" type="ogc:BinaryOperatorType"
+      substitutionGroup="ogc:expression"/>
+   <xsd:element name="Div" type="ogc:BinaryOperatorType"
+      substitutionGroup="ogc:expression"/>
+   <xsd:element name="PropertyName" type="ogc:PropertyNameType"
+      substitutionGroup="ogc:expression"/>
+   <xsd:element name="Function" type="ogc:FunctionType"
+      substitutionGroup="ogc:expression"/>
+   <xsd:element name="Literal" type="ogc:LiteralType"
+      substitutionGroup="ogc:expression"/>
+   <xsd:element name="expression" type="ogc:ExpressionType" abstract="true"/>
+   <!-- <xsd:complexType name="ExpressionType" abstract="true" mixed="true"/>
+     -->
+   <xsd:complexType name="ExpressionType" abstract="true"/>
+   <xsd:complexType name="BinaryOperatorType">
+      <xsd:complexContent>
+         <xsd:extension base="ogc:ExpressionType">
+            <xsd:sequence>
+               <xsd:element ref="ogc:expression" minOccurs="2" maxOccurs="2"/>
+            </xsd:sequence>
+         </xsd:extension>
+      </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="FunctionType">
+      <xsd:complexContent>
+         <xsd:extension base="ogc:ExpressionType">
+            <xsd:sequence>
+               <xsd:element ref="ogc:expression" minOccurs="0"
+                  maxOccurs="unbounded"/>
+            </xsd:sequence>
+            <xsd:attribute name="name" type="xsd:string" use="required"/>
+         </xsd:extension>
+      </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="LiteralType">
+      <xsd:complexContent mixed="true">
+         <xsd:extension base="ogc:ExpressionType">
+            <xsd:sequence>
+               <xsd:any minOccurs="0"/>
+            </xsd:sequence>
+         </xsd:extension>
+      </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="PropertyNameType">
+      <xsd:complexContent mixed="true">
+        <xsd:extension base="ogc:ExpressionType">
+          <xsd:sequence>
+            <xsd:any minOccurs="0"/>
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+   </xsd:complexType>
 </xsd:schema>

--- a/ogc-filter-v_1_1_0-schema/src/main/resources/filter/1.1.0/expr.xsd
+++ b/ogc-filter-v_1_1_0-schema/src/main/resources/filter/1.1.0/expr.xsd
@@ -1,60 +1,70 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsd:schema xmlns:ogc="http://www.opengis.net/ogc" xmlns:gml="http://www.opengis.net/gml" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.opengis.net/ogc" elementFormDefault="qualified" version="1.1.0">
-	<xsd:element name="Add" type="ogc:BinaryOperatorType" substitutionGroup="ogc:expression"/>
-	<xsd:element name="Sub" type="ogc:BinaryOperatorType" substitutionGroup="ogc:expression"/>
-	<xsd:element name="Mul" type="ogc:BinaryOperatorType" substitutionGroup="ogc:expression"/>
-	<xsd:element name="Div" type="ogc:BinaryOperatorType" substitutionGroup="ogc:expression"/>
-	<xsd:element name="PropertyName" type="ogc:PropertyNameType" substitutionGroup="ogc:expression"/>
-	<xsd:element name="Function" type="ogc:FunctionType" substitutionGroup="ogc:expression"/>
-	<xsd:element name="Literal" type="ogc:LiteralType" substitutionGroup="ogc:expression"/>
-	<xsd:element name="expression" type="ogc:ExpressionType" abstract="true"/>
-	<!-- <xsd:complexType name="ExpressionType" abstract="true" mixed="true"/>
-     -->
-	<xsd:complexType name="ExpressionType" abstract="true"/>
-	<xsd:complexType name="BinaryOperatorType">
-		<xsd:complexContent>
-			<xsd:extension base="ogc:ExpressionType">
-				<xsd:sequence>
-					<xsd:element ref="ogc:expression" minOccurs="2" maxOccurs="2"/>
-				</xsd:sequence>
-			</xsd:extension>
-		</xsd:complexContent>
-	</xsd:complexType>
-	<xsd:complexType name="FunctionType">
-		<xsd:complexContent>
-			<xsd:extension base="ogc:ExpressionType">
-				<xsd:sequence>
-					<xsd:element ref="ogc:expression" minOccurs="0" maxOccurs="unbounded"/>
-				</xsd:sequence>
-				<xsd:attribute name="name" type="xsd:string" use="required"/>
-			</xsd:extension>
-		</xsd:complexContent>
-	</xsd:complexType>
-	<xsd:complexType name="LiteralType" mixed="true">
-		<xsd:complexContent mixed="true">
-			<xsd:extension base="ogc:ExpressionType">
-				<xsd:sequence>
-					<xsd:any minOccurs="0"/>
-				</xsd:sequence>
-			</xsd:extension>
-		</xsd:complexContent>
-	</xsd:complexType>
-	<!-- this is the corrected version of PropertyNameType -->
-	<xsd:complexType name="PropertyNameType" mixed="true">
-		<xsd:complexContent mixed="true">
-			<xsd:extension base="ogc:ExpressionType">
-				<xsd:sequence>
-					<xsd:any minOccurs="0"/>
-				</xsd:sequence>
-			</xsd:extension>
-		</xsd:complexContent>
-	</xsd:complexType>
-	<!-- this was the original (OGC) version of PropertyNameType -->
-	<!--
-	<xsd:complexType name="PropertyNameType" mixed="true">
-		<xsd:complexContent mixed="true">
-			<xsd:extension base="ogc:ExpressionType"/>
-		</xsd:complexContent>
-	</xsd:complexType>
-	-->
+<xsd:schema xmlns:ogc="http://www.opengis.net/ogc"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="http://www.opengis.net/ogc"
+            elementFormDefault="qualified"
+            version="1.1.3">
+    <!--
+       filter is an OGC Standard.
+       Copyright (c) 2002,2003,2004,2010 Open Geospatial Consortium.
+       To obtain additional rights of use, visit http://www.opengeospatial.org/legal/ .
+
+       Updated: 2012-07-21
+    -->
+    <xsd:element name="Add" type="ogc:BinaryOperatorType"
+                 substitutionGroup="ogc:expression"/>
+    <xsd:element name="Sub" type="ogc:BinaryOperatorType"
+                 substitutionGroup="ogc:expression"/>
+    <xsd:element name="Mul" type="ogc:BinaryOperatorType"
+                 substitutionGroup="ogc:expression"/>
+    <xsd:element name="Div" type="ogc:BinaryOperatorType"
+                 substitutionGroup="ogc:expression"/>
+    <xsd:element name="PropertyName" type="ogc:PropertyNameType"
+                 substitutionGroup="ogc:expression"/>
+    <xsd:element name="Function" type="ogc:FunctionType"
+                 substitutionGroup="ogc:expression"/>
+    <xsd:element name="Literal" type="ogc:LiteralType"
+                 substitutionGroup="ogc:expression"/>
+    <xsd:element name="expression" type="ogc:ExpressionType" abstract="true"/>
+    <!-- <xsd:complexType name="ExpressionType" abstract="true" mixed="true"/>
+      -->
+    <xsd:complexType name="ExpressionType" abstract="true"/>
+    <xsd:complexType name="BinaryOperatorType">
+        <xsd:complexContent>
+            <xsd:extension base="ogc:ExpressionType">
+                <xsd:sequence>
+                    <xsd:element ref="ogc:expression" minOccurs="2" maxOccurs="2"/>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="FunctionType">
+        <xsd:complexContent>
+            <xsd:extension base="ogc:ExpressionType">
+                <xsd:sequence>
+                    <xsd:element ref="ogc:expression" minOccurs="0"
+                                 maxOccurs="unbounded"/>
+                </xsd:sequence>
+                <xsd:attribute name="name" type="xsd:string" use="required"/>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="LiteralType">
+        <xsd:complexContent mixed="true">
+            <xsd:extension base="ogc:ExpressionType">
+                <xsd:sequence>
+                    <xsd:any minOccurs="0"/>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="PropertyNameType">
+        <xsd:complexContent mixed="true">
+            <xsd:extension base="ogc:ExpressionType">
+                <xsd:sequence>
+                    <xsd:any minOccurs="0"/>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
 </xsd:schema>

--- a/ogc-filter-v_1_1_0-schema/src/main/resources/filter/1.1.0/filter.xsd
+++ b/ogc-filter-v_1_1_0-schema/src/main/resources/filter/1.1.0/filter.xsd
@@ -20,12 +20,12 @@ Copyright © 1994-2012 Open Geospatial Consortium, Inc.
  * content (the actual distance text node) to be set.
  **/
 -->
-<xsd:schema targetNamespace="http://www.opengis.net/ogc"
-   xmlns:ogc="http://www.opengis.net/ogc"
-   xmlns:gml="http://www.opengis.net/gml"
-   xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-   elementFormDefault="qualified"
-   version="1.1.0">
+<xsd:schema xmlns:ogc="http://www.opengis.net/ogc"
+            xmlns:gml="http://www.opengis.net/gml"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="http://www.opengis.net/ogc"
+            elementFormDefault="qualified"
+            version="1.1.0">
 
    <xsd:include schemaLocation="expr.xsd"/>
    <xsd:include schemaLocation="sort.xsd"/>
@@ -76,6 +76,9 @@ Copyright © 1994-2012 Open Geospatial Consortium, Inc.
    <xsd:element name="PropertyIsLike"
                 type="ogc:PropertyIsLikeType"
                 substitutionGroup="ogc:comparisonOps"/>
+    <xsd:element name="PropertyIsDivisibleBy"
+                 type="ogc:PropertyIsDivisibleByType"
+                 substitutionGroup="ogc:comparisonOps"/>
    <xsd:element name="PropertyIsFuzzy"
                 type="ogc:PropertyIsFuzzyType"
                 substitutionGroup="ogc:comparisonOps"/>
@@ -172,6 +175,16 @@ Copyright © 1994-2012 Open Geospatial Consortium, Inc.
          </xsd:extension>
       </xsd:complexContent>
    </xsd:complexType>
+    <xsd:complexType name="PropertyIsDivisibleByType">
+        <xsd:complexContent>
+            <xsd:extension base="ogc:ComparisonOpsType">
+                <xsd:sequence>
+                    <xsd:element ref="ogc:PropertyName"/>
+                    <xsd:element ref="ogc:Literal"/>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
    <xsd:complexType name="PropertyIsFuzzyType">
       <xsd:complexContent>
          <xsd:extension base="ogc:ComparisonOpsType">

--- a/ogc-filter-v_1_1_0-schema/src/main/resources/filter/1.1.0/filter.xsd
+++ b/ogc-filter-v_1_1_0-schema/src/main/resources/filter/1.1.0/filter.xsd
@@ -1,32 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-Copyright © 1994-2012 Open Geospatial Consortium, Inc.
--->
-<!--
-/**
- * Copyright (c) Codice Foundation
- *
- * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
- * General Public License as published by the Free Software Foundation, either version 3 of the
- * License, or any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
- * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
- * is distributed along with this program and can be found at
- * <http://www.gnu.org/licenses/lgpl.html>.
- *
- * line 236: Added mixed="true" to the complexType DistanceType to allow
- * content (the actual distance text node) to be set.
- **/
--->
 <xsd:schema xmlns:ogc="http://www.opengis.net/ogc"
             xmlns:gml="http://www.opengis.net/gml"
             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
             targetNamespace="http://www.opengis.net/ogc"
             elementFormDefault="qualified"
-            version="1.1.0">
+            version="1.1.3">
 
+    <xsd:annotation>
+        <xsd:documentation>
+            This XML Schema defines OGC query filter capabilities documents.
+            filter is an OGC Standard.
+
+            Copyright (c) 2002,2003,2004,2010 Open Geospatial Consortium.
+
+            To obtain additional rights of use, visit:
+            http://www.opengeospatial.org/legal/ .
+
+            Updated: 2012-07-21
+        </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:include schemaLocation="filterAll.xsd"/>
    <xsd:include schemaLocation="expr.xsd"/>
    <xsd:include schemaLocation="sort.xsd"/>
    <xsd:include schemaLocation="filterCapabilities.xsd"/>
@@ -156,8 +150,8 @@ Copyright © 1994-2012 Open Geospatial Consortium, Inc.
             <xsd:sequence>
                <xsd:element ref="ogc:expression" minOccurs="2" maxOccurs="2"/>
             </xsd:sequence>
-            <xsd:attribute name="matchCase" type="xsd:boolean"
-                           use="optional" default="true"/>
+             <xsd:attribute name="matchCase" type="xsd:boolean" use="optional"
+                            default="true"/>
          </xsd:extension>
       </xsd:complexContent>
    </xsd:complexType>
@@ -171,7 +165,8 @@ Copyright © 1994-2012 Open Geospatial Consortium, Inc.
             <xsd:attribute name="wildCard" type="xsd:string" use="required"/>
             <xsd:attribute name="singleChar" type="xsd:string" use="required"/>
             <xsd:attribute name="escapeChar" type="xsd:string" use="required"/>
-            <xsd:attribute name="matchCase" type="xsd:boolean" use="optional" default="true"/>
+             <xsd:attribute name="matchCase" type="xsd:boolean" use="optional"
+                            default="true"/>
          </xsd:extension>
       </xsd:complexContent>
    </xsd:complexType>
@@ -229,8 +224,8 @@ Copyright © 1994-2012 Open Geospatial Consortium, Inc.
       <xsd:complexContent>
          <xsd:extension base="ogc:SpatialOpsType">
             <xsd:sequence>
-               <xsd:element ref="ogc:PropertyName"/>
-               <xsd:choice>
+                <xsd:element ref="ogc:PropertyName" maxOccurs="2"/>
+                <xsd:choice minOccurs="0">
                   <xsd:element ref="gml:_Geometry"/>
                   <xsd:element ref="gml:Envelope"/>
                </xsd:choice>
@@ -242,7 +237,7 @@ Copyright © 1994-2012 Open Geospatial Consortium, Inc.
       <xsd:complexContent>
          <xsd:extension base="ogc:SpatialOpsType">
             <xsd:sequence>
-               <xsd:element ref="ogc:PropertyName"/>
+                <xsd:element ref="ogc:PropertyName" minOccurs="0"/>
                <xsd:element ref="gml:Envelope"/>
             </xsd:sequence>
          </xsd:extension>
@@ -259,12 +254,16 @@ Copyright © 1994-2012 Open Geospatial Consortium, Inc.
          </xsd:extension>
       </xsd:complexContent>
    </xsd:complexType>
-   <!-- 
-   Added mixed="true" to the complexType DistanceType to allow 
-   content (the actual distance text node) to be set.  
-   -->
-   <xsd:complexType name="DistanceType"  mixed="true">
-      <xsd:attribute name="units" type="xsd:string" use="required"/>
+    <!--
+ Added mixed="true" to the complexType DistanceType to allow
+ content (the actual distance text node) to be set.
+ -->
+    <xsd:complexType name="DistanceType">
+        <xsd:simpleContent>
+            <xsd:extension base="xsd:double">
+                <xsd:attribute name="units" type="xsd:anyURI" use="required"/>
+            </xsd:extension>
+        </xsd:simpleContent>
    </xsd:complexType>
    <xsd:complexType name="BinaryLogicOpType">
       <xsd:complexContent>
@@ -273,6 +272,7 @@ Copyright © 1994-2012 Open Geospatial Consortium, Inc.
                <xsd:element ref="ogc:comparisonOps"/>
                <xsd:element ref="ogc:spatialOps"/>
                <xsd:element ref="ogc:logicOps"/>
+                <xsd:element ref="ogc:Function"/>
             </xsd:choice>
          </xsd:extension>
       </xsd:complexContent>
@@ -285,6 +285,7 @@ Copyright © 1994-2012 Open Geospatial Consortium, Inc.
                   <xsd:element ref="ogc:comparisonOps"/>
                   <xsd:element ref="ogc:spatialOps"/>
                   <xsd:element ref="ogc:logicOps"/>
+                   <xsd:element ref="ogc:Function"/>
                </xsd:choice>
             </xsd:sequence>
          </xsd:extension>

--- a/ogc-filter-v_1_1_0-schema/src/main/resources/filter/1.1.0/filter.xsd
+++ b/ogc-filter-v_1_1_0-schema/src/main/resources/filter/1.1.0/filter.xsd
@@ -1,26 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsd:schema xmlns:ogc="http://www.opengis.net/ogc"
-            xmlns:gml="http://www.opengis.net/gml"
-            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            targetNamespace="http://www.opengis.net/ogc"
-            elementFormDefault="qualified"
-            version="1.1.3">
+<xsd:schema targetNamespace="http://www.opengis.net/ogc"
+   xmlns:ogc="http://www.opengis.net/ogc"
+   xmlns:gml="http://www.opengis.net/gml"
+   xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+   elementFormDefault="qualified"
+   version="1.1.3">
 
-    <xsd:annotation>
-        <xsd:documentation>
-            This XML Schema defines OGC query filter capabilities documents.
-            filter is an OGC Standard.
+   <xsd:annotation>
+      <xsd:documentation>
+         This XML Schema defines OGC query filter capabilities documents.
+         filter is an OGC Standard.
 
-            Copyright (c) 2002,2003,2004,2010 Open Geospatial Consortium.
+         Copyright (c) 2002,2003,2004,2010 Open Geospatial Consortium.
 
-            To obtain additional rights of use, visit:
-            http://www.opengeospatial.org/legal/ .
+         To obtain additional rights of use, visit:
+         http://www.opengeospatial.org/legal/ .
 
-            Updated: 2012-07-21
-        </xsd:documentation>
-    </xsd:annotation>
+         Updated: 2012-07-21
+      </xsd:documentation>
+   </xsd:annotation>
 
-    <xsd:include schemaLocation="filterAll.xsd"/>
+   <xsd:include schemaLocation="filterAll.xsd"/>
    <xsd:include schemaLocation="expr.xsd"/>
    <xsd:include schemaLocation="sort.xsd"/>
    <xsd:include schemaLocation="filterCapabilities.xsd"/>
@@ -70,9 +70,6 @@
    <xsd:element name="PropertyIsLike"
                 type="ogc:PropertyIsLikeType"
                 substitutionGroup="ogc:comparisonOps"/>
-    <xsd:element name="PropertyIsDivisibleBy"
-                 type="ogc:PropertyIsDivisibleByType"
-                 substitutionGroup="ogc:comparisonOps"/>
    <xsd:element name="PropertyIsFuzzy"
                 type="ogc:PropertyIsFuzzyType"
                 substitutionGroup="ogc:comparisonOps"/>
@@ -150,8 +147,8 @@
             <xsd:sequence>
                <xsd:element ref="ogc:expression" minOccurs="2" maxOccurs="2"/>
             </xsd:sequence>
-             <xsd:attribute name="matchCase" type="xsd:boolean" use="optional"
-                            default="true"/>
+            <xsd:attribute name="matchCase" type="xsd:boolean" use="optional"
+                           default="true"/>
          </xsd:extension>
       </xsd:complexContent>
    </xsd:complexType>
@@ -165,21 +162,11 @@
             <xsd:attribute name="wildCard" type="xsd:string" use="required"/>
             <xsd:attribute name="singleChar" type="xsd:string" use="required"/>
             <xsd:attribute name="escapeChar" type="xsd:string" use="required"/>
-             <xsd:attribute name="matchCase" type="xsd:boolean" use="optional"
-                            default="true"/>
+            <xsd:attribute name="matchCase" type="xsd:boolean" use="optional"
+                           default="true"/>
          </xsd:extension>
       </xsd:complexContent>
    </xsd:complexType>
-    <xsd:complexType name="PropertyIsDivisibleByType">
-        <xsd:complexContent>
-            <xsd:extension base="ogc:ComparisonOpsType">
-                <xsd:sequence>
-                    <xsd:element ref="ogc:PropertyName"/>
-                    <xsd:element ref="ogc:Literal"/>
-                </xsd:sequence>
-            </xsd:extension>
-        </xsd:complexContent>
-    </xsd:complexType>
    <xsd:complexType name="PropertyIsFuzzyType">
       <xsd:complexContent>
          <xsd:extension base="ogc:ComparisonOpsType">
@@ -224,8 +211,8 @@
       <xsd:complexContent>
          <xsd:extension base="ogc:SpatialOpsType">
             <xsd:sequence>
-                <xsd:element ref="ogc:PropertyName" maxOccurs="2"/>
-                <xsd:choice minOccurs="0">
+               <xsd:element ref="ogc:PropertyName" maxOccurs="2"/>
+               <xsd:choice minOccurs="0">
                   <xsd:element ref="gml:_Geometry"/>
                   <xsd:element ref="gml:Envelope"/>
                </xsd:choice>
@@ -237,7 +224,7 @@
       <xsd:complexContent>
          <xsd:extension base="ogc:SpatialOpsType">
             <xsd:sequence>
-                <xsd:element ref="ogc:PropertyName" minOccurs="0"/>
+               <xsd:element ref="ogc:PropertyName" minOccurs="0"/>
                <xsd:element ref="gml:Envelope"/>
             </xsd:sequence>
          </xsd:extension>
@@ -254,16 +241,12 @@
          </xsd:extension>
       </xsd:complexContent>
    </xsd:complexType>
-    <!--
- Added mixed="true" to the complexType DistanceType to allow
- content (the actual distance text node) to be set.
- -->
-    <xsd:complexType name="DistanceType">
-        <xsd:simpleContent>
-            <xsd:extension base="xsd:double">
-                <xsd:attribute name="units" type="xsd:anyURI" use="required"/>
-            </xsd:extension>
-        </xsd:simpleContent>
+   <xsd:complexType name="DistanceType">
+      <xsd:simpleContent>
+         <xsd:extension base="xsd:double">
+            <xsd:attribute name="units" type="xsd:anyURI" use="required"/>
+         </xsd:extension>
+      </xsd:simpleContent>
    </xsd:complexType>
    <xsd:complexType name="BinaryLogicOpType">
       <xsd:complexContent>
@@ -272,7 +255,7 @@
                <xsd:element ref="ogc:comparisonOps"/>
                <xsd:element ref="ogc:spatialOps"/>
                <xsd:element ref="ogc:logicOps"/>
-                <xsd:element ref="ogc:Function"/>
+               <xsd:element ref="ogc:Function"/>
             </xsd:choice>
          </xsd:extension>
       </xsd:complexContent>
@@ -285,7 +268,7 @@
                   <xsd:element ref="ogc:comparisonOps"/>
                   <xsd:element ref="ogc:spatialOps"/>
                   <xsd:element ref="ogc:logicOps"/>
-                   <xsd:element ref="ogc:Function"/>
+                  <xsd:element ref="ogc:Function"/>
                </xsd:choice>
             </xsd:sequence>
          </xsd:extension>

--- a/ogc-filter-v_1_1_0-schema/src/main/resources/filter/1.1.0/filterAll.xsd
+++ b/ogc-filter-v_1_1_0-schema/src/main/resources/filter/1.1.0/filterAll.xsd
@@ -1,24 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsd:schema
-        xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-        targetNamespace="http://www.opengis.net/ogc"
-        elementFormDefault="qualified"
-        version="1.1.3">
-    <!-- This version of filter/1.1.0 was previously versioned as '1.1.2' . -->
+<xsd:schema 
+   targetNamespace="http://www.opengis.net/ogc"
+   xmlns:ogc="http://www.opengis.net/ogc"
+   xmlns:gml="http://www.opengis.net/gml"
+   xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+   elementFormDefault="qualified"
+   version="1.1.3">
+   <!-- This version of filter/1.1.0 was previously versioned as '1.1.2' . -->
 
-    <xsd:annotation>
-        <xsd:documentation>
-            This XML Schema document includes and imports, directly or indirectly,
-            all the XML Schema defined by the Filter Encoding Standard.
+   <xsd:annotation>
+      <xsd:documentation>
+         This XML Schema document includes and imports, directly or indirectly,
+         all the XML Schema defined by the Filter Encoding Standard.
 
-            Filter Encoding is an OGC Standard.
-            Copyright (c) 2010 Open Geospatial Consortium.
-            To obtain additional rights of use, visit http://www.opengeospatial.org/legal/ .
-        </xsd:documentation>
-    </xsd:annotation>
+         Filter Encoding is an OGC Standard.
+         Copyright (c) 2010 Open Geospatial Consortium.
+         To obtain additional rights of use, visit http://www.opengeospatial.org/legal/ .
+      </xsd:documentation>
+   </xsd:annotation>
 
-    <xsd:include schemaLocation="filter.xsd"/>
-    <xsd:include schemaLocation="expr.xsd"/>
-    <xsd:include schemaLocation="sort.xsd"/>
-    <xsd:include schemaLocation="filterCapabilities.xsd"/>
+   <xsd:include schemaLocation="filter.xsd"/>
+   <xsd:include schemaLocation="expr.xsd"/>
+   <xsd:include schemaLocation="sort.xsd"/>
+   <xsd:include schemaLocation="filterCapabilities.xsd"/>
 </xsd:schema>

--- a/ogc-filter-v_1_1_0-schema/src/main/resources/filter/1.1.0/filterAll.xsd
+++ b/ogc-filter-v_1_1_0-schema/src/main/resources/filter/1.1.0/filterAll.xsd
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        targetNamespace="http://www.opengis.net/ogc"
+        elementFormDefault="qualified"
+        version="1.1.3">
+    <!-- This version of filter/1.1.0 was previously versioned as '1.1.2' . -->
+
+    <xsd:annotation>
+        <xsd:documentation>
+            This XML Schema document includes and imports, directly or indirectly,
+            all the XML Schema defined by the Filter Encoding Standard.
+
+            Filter Encoding is an OGC Standard.
+            Copyright (c) 2010 Open Geospatial Consortium.
+            To obtain additional rights of use, visit http://www.opengeospatial.org/legal/ .
+        </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:include schemaLocation="filter.xsd"/>
+    <xsd:include schemaLocation="expr.xsd"/>
+    <xsd:include schemaLocation="sort.xsd"/>
+    <xsd:include schemaLocation="filterCapabilities.xsd"/>
+</xsd:schema>

--- a/ogc-filter-v_1_1_0-schema/src/main/resources/filter/1.1.0/filterCapabilities.xsd
+++ b/ogc-filter-v_1_1_0-schema/src/main/resources/filter/1.1.0/filterCapabilities.xsd
@@ -5,11 +5,16 @@
         xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         targetNamespace="http://www.opengis.net/ogc"
         elementFormDefault="qualified"
-        version="1.1.0">
+        version="1.1.3">
    <xsd:annotation>
       <xsd:documentation>
          This XML Schema defines OGC query filter capabilities documents.
-         Copyright (c) 2002, 2003, 2004 OpenGIS, All Rights Reserved. 
+
+          filter is an OGC Standard.
+          Copyright (c) 2002,2003,2004,2010 Open Geospatial Consortium.
+          To obtain additional rights of use, visit http://www.opengeospatial.org/legal/ .
+
+          Updated: 2012-07-21
       </xsd:documentation>
    </xsd:annotation>
    <xsd:element name="Filter_Capabilities">

--- a/ogc-filter-v_1_1_0-schema/src/main/resources/filter/1.1.0/filterCapabilities.xsd
+++ b/ogc-filter-v_1_1_0-schema/src/main/resources/filter/1.1.0/filterCapabilities.xsd
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsd:schema
-        xmlns:ogc="http://www.opengis.net/ogc"
-        xmlns:gml="http://www.opengis.net/gml"
-        xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-        targetNamespace="http://www.opengis.net/ogc"
-        elementFormDefault="qualified"
-        version="1.1.3">
+   targetNamespace="http://www.opengis.net/ogc"
+   xmlns:ogc="http://www.opengis.net/ogc"
+   xmlns:gml="http://www.opengis.net/gml"
+   xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+   elementFormDefault="qualified"
+   version="1.1.3">
    <xsd:annotation>
       <xsd:documentation>
          This XML Schema defines OGC query filter capabilities documents.
-
-          filter is an OGC Standard.
-          Copyright (c) 2002,2003,2004,2010 Open Geospatial Consortium.
-          To obtain additional rights of use, visit http://www.opengeospatial.org/legal/ .
-
-          Updated: 2012-07-21
+         
+         filter is an OGC Standard.
+         Copyright (c) 2002,2003,2004,2010 Open Geospatial Consortium.
+         To obtain additional rights of use, visit http://www.opengeospatial.org/legal/ .
+         
+         Updated: 2012-07-21
       </xsd:documentation>
    </xsd:annotation>
    <xsd:element name="Filter_Capabilities">
@@ -129,7 +129,6 @@
          <xsd:enumeration value="Between"/>
          <xsd:enumeration value="NullCheck"/>
          <xsd:enumeration value="Fuzzy"/>
-          <xsd:enumeration value="DivisibleBy"/>
       </xsd:restriction>
    </xsd:simpleType>
    <xsd:complexType name="ArithmeticOperatorsType">

--- a/ogc-filter-v_1_1_0-schema/src/main/resources/filter/1.1.0/filterCapabilities.xsd
+++ b/ogc-filter-v_1_1_0-schema/src/main/resources/filter/1.1.0/filterCapabilities.xsd
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsd:schema
-   targetNamespace="http://www.opengis.net/ogc"
-   xmlns:ogc="http://www.opengis.net/ogc"
-   xmlns:gml="http://www.opengis.net/gml"
-   xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-   elementFormDefault="qualified"
-   version="1.1.0">
+        xmlns:ogc="http://www.opengis.net/ogc"
+        xmlns:gml="http://www.opengis.net/gml"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        targetNamespace="http://www.opengis.net/ogc"
+        elementFormDefault="qualified"
+        version="1.1.0">
    <xsd:annotation>
       <xsd:documentation>
          This XML Schema defines OGC query filter capabilities documents.
@@ -124,6 +124,7 @@
          <xsd:enumeration value="Between"/>
          <xsd:enumeration value="NullCheck"/>
          <xsd:enumeration value="Fuzzy"/>
+          <xsd:enumeration value="DivisibleBy"/>
       </xsd:restriction>
    </xsd:simpleType>
    <xsd:complexType name="ArithmeticOperatorsType">

--- a/ogc-filter-v_1_1_0-schema/src/main/resources/filter/1.1.0/sort.xsd
+++ b/ogc-filter-v_1_1_0-schema/src/main/resources/filter/1.1.0/sort.xsd
@@ -1,11 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsd:schema
-   targetNamespace="http://www.opengis.net/ogc"
-   xmlns:ogc="http://www.opengis.net/ogc"
-   xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-   elementFormDefault="qualified"
-   version="1.1.0">
+        xmlns:ogc="http://www.opengis.net/ogc"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        targetNamespace="http://www.opengis.net/ogc"
+        elementFormDefault="qualified"
+        version="1.1.3">
+    <!--
+       filter is an OGC Standard.
+       Copyright (c) 2002,2003,2004,2010 Open Geospatial Consortium.
+       To obtain additional rights of use, visit http://www.opengeospatial.org/legal/ .
 
+       Updated: 2012-07-21
+    -->
+    <xsd:include schemaLocation="filterAll.xsd"/>
    <xsd:include schemaLocation="expr.xsd"/>
 
    <!-- ============================================= -->

--- a/ogc-filter-v_1_1_0-schema/src/main/resources/filter/1.1.0/sort.xsd
+++ b/ogc-filter-v_1_1_0-schema/src/main/resources/filter/1.1.0/sort.xsd
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsd:schema
-        xmlns:ogc="http://www.opengis.net/ogc"
-        xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-        targetNamespace="http://www.opengis.net/ogc"
-        elementFormDefault="qualified"
-        version="1.1.3">
-    <!--
-       filter is an OGC Standard.
-       Copyright (c) 2002,2003,2004,2010 Open Geospatial Consortium.
-       To obtain additional rights of use, visit http://www.opengeospatial.org/legal/ .
-
-       Updated: 2012-07-21
-    -->
-    <xsd:include schemaLocation="filterAll.xsd"/>
+   targetNamespace="http://www.opengis.net/ogc"
+   xmlns:ogc="http://www.opengis.net/ogc"
+   xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+   elementFormDefault="qualified"
+   version="1.1.3">
+   <!-- 
+      filter is an OGC Standard.
+      Copyright (c) 2002,2003,2004,2010 Open Geospatial Consortium.
+      To obtain additional rights of use, visit http://www.opengeospatial.org/legal/ .
+      
+      Updated: 2012-07-21
+   -->
+   <xsd:include schemaLocation="filterAll.xsd"/>
    <xsd:include schemaLocation="expr.xsd"/>
 
    <!-- ============================================= -->


### PR DESCRIPTION
I was going to add PropertyIsDivisibleBy but it turned out not to be necessary. I ended up upgraded to 1.1.3 since that was what CSW 2.0.2 should use.  It may be possible to get rid of this all together and use https://github.com/highsource/ogc-schemas except for the fact that we have PropertyIsFuzzy element added here and I don't think it can be removed without causing a backward compatibility issue. These schemas are the fixed xsd's copied from https://github.com/highsource/ogc-schemas/blob/master/schemas/src/main/resources/ogc/filter/1.1.0/filter.xsd with PropertyIsFuzzy added.

@pklinef could you review

I made the changes to support this version of the schema but none of these changes are actually necessary for my PR.