### PR TITLE
DDF-4197 Upgrading bouncy-castle versions used by the tika-parsers

### DIFF
--- a/tika-bundle/pom.xml
+++ b/tika-bundle/pom.xml
@@ -123,17 +123,17 @@
         <dependency>
             <groupId>org.apache.pdfbox</groupId>
             <artifactId>pdfbox-debugger</artifactId>
-            <version>2.0.9</version>
+            <version>2.0.11</version>
         </dependency>
         <dependency>
             <groupId>org.apache.pdfbox</groupId>
             <artifactId>pdfbox</artifactId>
-            <version>2.0.9</version>
+            <version>2.0.11</version>
         </dependency>
         <dependency>
             <groupId>org.apache.pdfbox</groupId>
             <artifactId>pdfbox-tools</artifactId>
-            <version>2.0.9</version>
+            <version>2.0.11</version>
         </dependency>
         <dependency>
             <groupId>com.esri.geometry</groupId>

--- a/tika-bundle/pom.xml
+++ b/tika-bundle/pom.xml
@@ -45,6 +45,21 @@
         </repository>
     </repositories>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcprov-jdk15on</artifactId>
+                <version>1.60</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcmail-jdk15on</artifactId>
+                <version>1.60</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.tika</groupId>


### PR DESCRIPTION
Bouncycastle bcprov-jdk15on v1.54 was found to have a vulnerability in the tika-bundle library. This PR forces the tika-parsers to use the updated version of bouncy castle without having to upgrade Tika to 1.9. 

[DDF-4197](https://codice.atlassian.net/browse/DDF-4197)

@coyotesqrl @brjeter @blen-desta 
@clockard @bdeining 