### PR TITLE
DDF-04543 Upgrade Jackson from 2.9.5 to 2.9.8

### DIFF
--- a/tika-bundle/pom.xml
+++ b/tika-bundle/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.codice.thirdparty</groupId>
     <artifactId>tika-bundle</artifactId>
-    <version>1.18.0_3</version>
+    <version>1.18.0_4</version>
 
     <name>Codice :: Thirdparty :: Apache Tika OSGi Bundle</name>
     <packaging>bundle</packaging>
@@ -143,17 +143,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.9.5</version>
+            <version>2.9.8</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.5</version>
+            <version>2.9.8</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.9.5</version>
+            <version>2.9.8</version>
         </dependency>
         <dependency>
             <groupId>org.geotools</groupId>


### PR DESCRIPTION
Upgrades the version of Jackson to avoid CVEs.

[See the test steps on the DDF PR](https://github.com/codice/ddf/pull/4544).

[Issue #4543](https://github.com/codice/ddf/issues/4543).